### PR TITLE
Support newer python

### DIFF
--- a/class_only_design.wpr
+++ b/class_only_design.wpr
@@ -25,3 +25,4 @@ proj.file-list = [loc('setup.py'),
 proj.file-type = 'shared'
 testing.auto-test-file-specs = (('glob',
                                  'test_*.py'),)
+testing.test-framework = {None: ':internal pytest'}

--- a/class_only_design/__init__.py
+++ b/class_only_design/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Tom Rutherford"""
 __email__ = "foreverwintr@gmail.com"
-__version__ = "0.3.0"
+__version__ = "1.0.0"
 
 from class_only_design.api import ClassOnly
 from class_only_design.api import Namespace

--- a/class_only_design/tests/test_class_only.py
+++ b/class_only_design/tests/test_class_only.py
@@ -76,7 +76,8 @@ class TestClassOnly(unittest.TestCase):
         # classes. For this reason, we disallow using constant with non class_only
         # classes.
 
-        with self.assertRaises(TypeError):
+        # In python3.11, ANY exception in __set_name__ result in RuntimeError.
+        with self.assertRaises((TypeError, RuntimeError)):
 
             class Class:
                 @constant

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest
+black

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311, py312, py313, py314
+envlist = py311, py312, py313
 
 [testenv]
 deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py35
+envlist = py311, py312, py313, py314
 
 [testenv]
 deps = coverage


### PR DESCRIPTION
This updates tests to use newer python versions, and bumps the version of this library to 1.0. I will draft a release after this is merged. 